### PR TITLE
Bug fix for parsing triggers that caused the app to completely crash.…

### DIFF
--- a/src/services/AppServices.m
+++ b/src/services/AppServices.m
@@ -1688,6 +1688,7 @@
 - (void) parseTrigger:(ARISServiceResult *)result
 {
     NSDictionary *triggerDict= (NSDictionary *)result.resultData;
+    if(!result.resultData || [result.resultData isEqual:[NSNull null]]) return;
     Trigger *trigger = [[Trigger alloc] initWithDictionary:triggerDict];
     _ARIS_NOTIF_SEND_(@"SERVICES_TRIGGER_RECEIVED", nil, @{@"trigger":trigger});
 }


### PR DESCRIPTION
…  Had to do with attempting to parse a trigger that had a return data array of null.  Added a resultData check to parseTrigger function similar to the same check in parseInstance.